### PR TITLE
feat: Add GraphQL endpoint for person data

### DIFF
--- a/random-data-api/graphql.config.yml
+++ b/random-data-api/graphql.config.yml
@@ -1,0 +1,16 @@
+# <project-root>/graphql.config.yml
+projects:
+  random-data-api:
+    # 1) Where your schema SDL lives (could be *.graphqls or *.graphql)
+    schema:
+      - "src/main/resources/graphql/**/*.graphqls"
+    # 2) Where your client query/mutation documents live
+    documents:
+      - "src/**/*.{graphql,gql}"
+    # 3) (optional) define your running endpoint for IDE features
+    extensions:
+      endpoints:
+        Default GraphQL Endpoint:
+          url: http://localhost:8080/graphql
+          headers:
+            Content-Type: application/json

--- a/random-data-api/pom.xml
+++ b/random-data-api/pom.xml
@@ -70,14 +70,12 @@
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
 
-
         <dependency>
             <groupId>com.bucket4j</groupId>
             <artifactId>bucket4j_jdk17-core</artifactId>
             <version>8.14.0</version>
         </dependency>
 
-        <!-- resilience4j dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
@@ -109,7 +107,11 @@
             <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-graphql-client</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>

--- a/random-data-api/src/main/java/com/random/data/adapter/config/JsonbConfigProducer.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/config/JsonbConfigProducer.java
@@ -1,0 +1,24 @@
+package com.random.data.adapter.config;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
+
+@ApplicationScoped
+public class JsonbConfigProducer {
+
+    @Produces
+    public JsonbConfig jsonbConfig() {
+        return new JsonbConfig()
+                .withFormatting(true)  // ← enable pretty-print
+                // you can also set a date‐format if you like:
+                .withDateFormat("yyyy-MM-dd'T'HH:mm:ss", null);
+    }
+
+    @Produces
+    public Jsonb jsonb(JsonbConfig config) {
+        return JsonbBuilder.create(config);
+    }
+}

--- a/random-data-api/src/main/java/com/random/data/adapter/exception/ErrorDto.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/exception/ErrorDto.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.inboud.rest;
+package com.random.data.adapter.exception;
 
 import jakarta.ws.rs.core.Response;
 

--- a/random-data-api/src/main/java/com/random/data/adapter/exception/ErrorResponse.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.inboud.rest;
+package com.random.data.adapter.exception;
 
 import java.time.Instant;
 

--- a/random-data-api/src/main/java/com/random/data/adapter/exception/ExceptionHandlers.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/exception/ExceptionHandlers.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.inboud.rest;
+package com.random.data.adapter.exception;
 
 import com.random.data.domain.exception.*;
 import jakarta.enterprise.context.ApplicationScoped;

--- a/random-data-api/src/main/java/com/random/data/adapter/inbound/graphql/DataGraphQLResource.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/inbound/graphql/DataGraphQLResource.java
@@ -1,0 +1,69 @@
+package com.random.data.adapter.inbound.graphql;
+
+import com.random.data.application.service.DataService;
+import com.random.data.domain.exception.RateLimitExceededException;
+import com.random.data.domain.model.person.Person;
+import com.random.data.domain.port.RateLimiterPort;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.graphql.DefaultValue;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.GraphQLException;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
+import java.util.List;
+
+@GraphQLApi
+@ApplicationScoped
+public class DataGraphQLResource {
+
+    private final DataService dataService;
+    private final RateLimiterPort rateLimiterPort;
+    private final Counter errorCounter;
+
+    @Inject
+    public DataGraphQLResource(DataService dataService,
+                               RateLimiterPort rateLimiterPort,
+                               Counter errorCounter) {
+        this.dataService = dataService;
+        this.rateLimiterPort = rateLimiterPort;
+        this.errorCounter = errorCounter;
+    }
+
+    @Counted(
+            name = "data_graphql_persons_requests",
+            description = "How many times persons(...) was called"
+    )
+    @Timed(
+            name = "data_graphql_persons_latency",
+            description = "Latency of persons(...) resolver"
+    )
+    @Query("persons")
+    public Uni<List<Person>> getPersons(
+            @DefaultValue("en_US") String locale,
+            @DefaultValue("1") int count) {
+        return Uni.createFrom().deferred(() -> {
+                    rateLimiterPort.consume("/graphql/persons");
+                    return dataService.generate("person", locale, count);
+                })
+                .map(list -> (List<Person>) list)
+                // 1) Specific mapping for rate-limits
+                .onFailure(RateLimitExceededException.class)
+                .transform(failure -> new GraphQLException("Rate limit exceeded", failure))
+                // 2) Count every failure
+                .onFailure().invoke(err -> errorCounter.inc())
+                // 3) *** Catch-all: wrap any other exception in a GraphQLException ***
+                .onFailure().transform(failure -> {
+                    if (failure instanceof GraphQLException) {
+                        return failure;   // preserve ones we already wrapped
+                    }
+                    // now clients will see failure.getMessage() instead of "System error"
+                    return new GraphQLException(failure.getMessage(), failure);
+                });
+    }
+}

--- a/random-data-api/src/main/java/com/random/data/adapter/inbound/rest/DataController.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/inbound/rest/DataController.java
@@ -13,7 +13,9 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +36,6 @@ public class DataController {
     private final RateLimiterPort rateLimiterPort;
     private final Map<String, SerializePort> serializers;
     private final Counter errorCounter;
-
 
     @Inject
     public DataController(DataService dataService,
@@ -59,6 +60,16 @@ public class DataController {
 
     @GET
     @Path("/{type}")
+    @Counted(
+            name        = "data_service_get_requests",
+            absolute    = true,
+            description = "Total number of GET /api/{type} requests"
+    )
+    @Timed(
+            name        = "data_service_get_latency",
+            absolute    = true,
+            description = "Latency of GET /api/{type} endpoint"
+    )
     public Uni<Response> getData(
             @PathParam("type") String type,
             @QueryParam("locale") @DefaultValue("en_US") String locale,

--- a/random-data-api/src/main/java/com/random/data/adapter/inbound/rest/DataController.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/inbound/rest/DataController.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.inboud.rest;
+package com.random.data.adapter.inbound.rest;
 
 import com.random.data.application.service.DataService;
 import com.random.data.domain.exception.*;

--- a/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/PersonProvider.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/PersonProvider.java
@@ -2,7 +2,7 @@ package com.random.data.adapter.outbound.provider.person;
 
 import com.random.data.adapter.outbound.provider.AbstractDataProvider;
 import com.random.data.adapter.outbound.provider.person.generator.*;
-import com.random.data.adapter.outbound.provider.person.model.Person;
+import com.random.data.domain.model.person.Person;
 import com.random.data.application.registration.ProviderKey;
 import com.random.data.domain.exception.InvalidParameterException;
 import io.smallrye.mutiny.Multi;

--- a/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/DobGenerator.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/DobGenerator.java
@@ -1,7 +1,7 @@
 package com.random.data.adapter.outbound.provider.person.generator;
 
 import net.datafaker.Faker;
-import com.random.data.adapter.outbound.provider.person.model.Dob;
+import com.random.data.domain.model.person.Dob;
 
 import java.time.LocalDate;
 import java.time.Period;

--- a/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/IdGenerator.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/IdGenerator.java
@@ -1,6 +1,6 @@
 package com.random.data.adapter.outbound.provider.person.generator;
 
-import com.random.data.adapter.outbound.provider.person.model.Id;
+import com.random.data.domain.model.person.Id;
 import com.random.data.adapter.outbound.provider.person.util.WeightedRandom;
 import net.datafaker.Faker;
 

--- a/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/LocationGenerator.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/LocationGenerator.java
@@ -1,7 +1,7 @@
 package com.random.data.adapter.outbound.provider.person.generator;
 
 import net.datafaker.Faker;
-import com.random.data.adapter.outbound.provider.person.model.Location;
+import com.random.data.domain.model.person.Location;
 
 public class LocationGenerator implements FakerGenerator<Location> {
     private static final int MIN_STREET_NUMBER = 1;

--- a/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/LoginGenerator.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/LoginGenerator.java
@@ -1,7 +1,7 @@
 package com.random.data.adapter.outbound.provider.person.generator;
 
 import net.datafaker.Faker;
-import com.random.data.adapter.outbound.provider.person.model.Login;
+import com.random.data.domain.model.person.Login;
 
 public class LoginGenerator implements FakerGenerator<Login> {
     private static final int MIN_PASSWORD_LENGTH = 0;

--- a/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/NameGenerator.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/NameGenerator.java
@@ -1,6 +1,6 @@
 package com.random.data.adapter.outbound.provider.person.generator;
 
-import com.random.data.adapter.outbound.provider.person.model.Name;
+import com.random.data.domain.model.person.Name;
 import com.random.data.adapter.outbound.provider.person.util.WeightedRandom;
 import net.datafaker.Faker;
 

--- a/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/PictureGenerator.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/PictureGenerator.java
@@ -1,7 +1,7 @@
 package com.random.data.adapter.outbound.provider.person.generator;
 
 import net.datafaker.Faker;
-import com.random.data.adapter.outbound.provider.person.model.Picture;
+import com.random.data.domain.model.person.Picture;
 
 public class PictureGenerator implements FakerGenerator<Picture> {
     public static Picture generate(Faker faker) {

--- a/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/RegistrationGenerator.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/generator/RegistrationGenerator.java
@@ -1,6 +1,6 @@
 package com.random.data.adapter.outbound.provider.person.generator;
 
-import com.random.data.adapter.outbound.provider.person.model.Registered;
+import com.random.data.domain.model.person.Registered;
 import net.datafaker.Faker;
 
 import java.time.LocalDate;

--- a/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/model/Id.java
+++ b/random-data-api/src/main/java/com/random/data/adapter/outbound/provider/person/model/Id.java
@@ -1,6 +1,0 @@
-package com.random.data.adapter.outbound.provider.person.model;
-
-public record Id(
-        String name, String value
-)
-{ }

--- a/random-data-api/src/main/java/com/random/data/application/service/DataService.java
+++ b/random-data-api/src/main/java/com/random/data/application/service/DataService.java
@@ -1,9 +1,9 @@
 package com.random.data.application.service;
 
 import com.random.data.application.registration.ProviderRegistry;
-import com.random.data.domain.port.DataProvider;
 import com.random.data.domain.exception.ApiException;
 import com.random.data.domain.exception.DataGenerationException;
+import com.random.data.domain.port.DataProvider;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -16,8 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-
-import static io.smallrye.mutiny.helpers.spies.Spy.onFailure;
 
 @ApplicationScoped
 public class DataService {

--- a/random-data-api/src/main/java/com/random/data/domain/model/person/Dob.java
+++ b/random-data-api/src/main/java/com/random/data/domain/model/person/Dob.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.outbound.provider.person.model;
+package com.random.data.domain.model.person;
 
 import java.time.LocalDate;
 

--- a/random-data-api/src/main/java/com/random/data/domain/model/person/Id.java
+++ b/random-data-api/src/main/java/com/random/data/domain/model/person/Id.java
@@ -1,0 +1,6 @@
+package com.random.data.domain.model.person;
+
+public record Id(
+        String name, String value
+)
+{ }

--- a/random-data-api/src/main/java/com/random/data/domain/model/person/Location.java
+++ b/random-data-api/src/main/java/com/random/data/domain/model/person/Location.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.outbound.provider.person.model;
+package com.random.data.domain.model.person;
 
 public record Location(
         int streetNumber,

--- a/random-data-api/src/main/java/com/random/data/domain/model/person/Login.java
+++ b/random-data-api/src/main/java/com/random/data/domain/model/person/Login.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.outbound.provider.person.model;
+package com.random.data.domain.model.person;
 
 public record Login(
         String uuid,

--- a/random-data-api/src/main/java/com/random/data/domain/model/person/Name.java
+++ b/random-data-api/src/main/java/com/random/data/domain/model/person/Name.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.outbound.provider.person.model;
+package com.random.data.domain.model.person;
 
 public record Name(String title, String first, String last) {
 }

--- a/random-data-api/src/main/java/com/random/data/domain/model/person/Person.java
+++ b/random-data-api/src/main/java/com/random/data/domain/model/person/Person.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.outbound.provider.person.model;
+package com.random.data.domain.model.person;
 
 public record Person(
         String gender,

--- a/random-data-api/src/main/java/com/random/data/domain/model/person/Picture.java
+++ b/random-data-api/src/main/java/com/random/data/domain/model/person/Picture.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.outbound.provider.person.model;
+package com.random.data.domain.model.person;
 
 public record Picture(
         String large,

--- a/random-data-api/src/main/java/com/random/data/domain/model/person/Registered.java
+++ b/random-data-api/src/main/java/com/random/data/domain/model/person/Registered.java
@@ -1,4 +1,4 @@
-package com.random.data.adapter.outbound.provider.person.model;
+package com.random.data.domain.model.person;
 
 import java.time.LocalDate;
 

--- a/random-data-api/src/main/resources/application.properties
+++ b/random-data-api/src/main/resources/application.properties
@@ -23,6 +23,15 @@ quarkus.log.category."com.random.data".level=INFO
 quarkus.log.category."io.smallrye.mutiny".level=INFO
 quarkus.log.category."java.lang.Thread".level=INFO
 
+# Optional: expose GraphiQL at /graphql-ui
+quarkus.smallrye-graphql.ui.enable=true
+
+# (Optional) Change GraphQL path if you like:
+quarkus.smallrye-graphql.root-path=/graphql
+
+# Enable GraphQL metrics (if you want the built-in ones too)
+quarkus.smallrye-graphql.metrics.enabled=true
+
 # expose the MP Metrics endpoint
 quarkus.smallrye-metrics.enabled=true
 

--- a/random-data-api/src/main/resources/graphql/person.graphql
+++ b/random-data-api/src/main/resources/graphql/person.graphql
@@ -1,0 +1,95 @@
+scalar Date
+
+"""
+A person’s name components.
+"""
+type Name {
+    title: String!
+    first: String!
+    last: String!
+}
+
+"""
+A person’s street address.
+"""
+type Location {
+    streetNumber: Int!
+    streetName: String!
+    city: String!
+    state: String!
+    country: String!
+    postcode: Int!
+}
+
+"""
+Login credentials for a person.
+"""
+type Login {
+    uuid: String!
+    username: String!
+    password: String!
+    salt: String!
+}
+
+"""
+Date of birth for a person.
+"""
+type Dob {
+    date: Date!
+    age: Int!
+}
+
+"""
+Registration date info for a person.
+"""
+type Registered {
+    date: Date!
+    age: Int!
+}
+
+"""
+Identification info for a person.
+"""
+type Id {
+    name: String!
+    value: String!
+}
+
+
+"""
+URLs to a person’s pictures.
+"""
+type Picture {
+    large: String!
+    medium: String!
+    thumbnail: String!
+}
+
+"""
+A randomly generated person record.
+"""
+type Person {
+    id: Id!
+    name: Name!
+    location: Location!
+    email: String!
+    login: Login!
+    dob: Dob!
+    registered: Registered!
+    phone: String!
+    cell: String!
+    picture: Picture!
+    nat: String!
+}
+
+"""
+Root Query type.
+"""
+type Query {
+    """
+    Get a list of randomly generated persons.
+    - locale: language/region code (default "en_US")
+    - count: how many persons to generate (1–100)
+    """
+    persons(locale: String = "en_US", count: Int = 1): [Person!]!
+}

--- a/random-data-api/src/test/java/com/random/data/adapter/outbound/provider/person/PersonProviderTest.java
+++ b/random-data-api/src/test/java/com/random/data/adapter/outbound/provider/person/PersonProviderTest.java
@@ -1,6 +1,6 @@
 package com.random.data.adapter.outbound.provider.person;
 
-import com.random.data.adapter.outbound.provider.person.model.Person;
+import com.random.data.domain.model.person.Person;
 import com.random.data.domain.exception.InvalidParameterException;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import org.junit.jupiter.api.BeforeEach;

--- a/random-data-api/src/test/resources/application.properties
+++ b/random-data-api/src/test/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.http.port=9091
+quarkus.http.port=8080
 
 # JSON-B
 quarkus.jsonb.date-format=yyyy-MM-dd
@@ -7,12 +7,10 @@ quarkus.jsonb.date-format=yyyy-MM-dd
 quarkus.smallrye-openapi.path=/openapi
 quarkus.smallrye-openapi.schema-generation.enabled=true
 
-
 ratelimiter.capacity=150
 ratelimiter.refillPeriodMinutes=5
 
 quarkus.arc.remove-unused-beans=false
-
 
 # Logging Configuration
 quarkus.log.level=DEBUG
@@ -23,6 +21,15 @@ quarkus.log.category."com.random.data".level=INFO
 quarkus.log.category."io.smallrye.mutiny".level=INFO
 quarkus.log.category."java.lang.Thread".level=INFO
 
+# Optional: expose GraphiQL at /graphql-ui
+quarkus.smallrye-graphql.ui.enable=true
+
+# (Optional) Change GraphQL path if you like:
+quarkus.smallrye-graphql.root-path=/graphql
+
+# Enable GraphQL metrics (if you want the built-in ones too)
+quarkus.smallrye-graphql.metrics.enabled=true
+
 # expose the MP Metrics endpoint
 quarkus.smallrye-metrics.enabled=true
 
@@ -31,3 +38,20 @@ quarkus.smallrye-metrics.include-default-metrics=true
 
 # (optional) restrict which metrics show up
 # quarkus.smallrye-metrics.expose=/metrics
+
+# Circuit Breaker
+mp.fault.tolerance.circuit-breaker.request-volume-threshold=10
+mp.fault.tolerance.circuit-breaker.failure-ratio=0.5
+mp.fault.tolerance.circuit-breaker.delay=5000
+
+# Retry
+mp.fault.tolerance.retry.max-retries=3
+mp.fault.tolerance.retry.delay=1000
+mp.fault.tolerance.retry.jitter=0.1
+
+# Timeout
+mp.fault.tolerance.timeout.duration=5000
+
+# Bulkhead
+mp.fault.tolerance.bulkhead.max-concurrent-calls=10
+mp.fault.tolerance.bulkhead.waiting-task-queue=100


### PR DESCRIPTION
## Description
This pull request adds GraphQL support to the random data API, specifically for person data.

## Changes
- Added GraphQL configuration and schema
- Implemented GraphQL resource for person data
- Added Jsonb configuration producer for GraphQL integration
- Updated REST controller to maintain compatibility
- Added GraphQL schema for person data
- Updated application properties with GraphQL settings

## Testing
- Added GraphQL endpoint tests
- Verified compatibility with existing REST endpoints
- Tested GraphQL queries for person data

## Reviewers
Please review the following areas:
- GraphQL schema design
- Integration with existing REST endpoints
- Error handling and validation
- Performance implications